### PR TITLE
Add wei:pull bot to automatically pull changes from kubeflow/kfp-tekton repo

### DIFF
--- a/.github/pull.yml
+++ b/.github/pull.yml
@@ -1,0 +1,8 @@
+version: "1"
+rules:
+  - base: master
+    upstream: kfp-tekton:master
+    mergeMethod: none # don't automatically merge
+    mergeUnstable: false
+label: "do-not-merge/hold"
+conflictLabel: "needs-rebase"


### PR DESCRIPTION
With the wei/pull bot we can automatically update the ODH Kubeflow fork with last changes from upstream.

When the bot detects a change in the upstream, it will create a new PR. This PR won't be merged until we approve it using the Openshift CI commands.

Example PR -> https://github.com/samuelvl/kubeflow/pull/26

Additionally to merging this change we have to install the [Pull app](https://github.com/wei/pull#basic-setup)