### PR TITLE
fix(frontend) Update access arguments for the ml pipelines UI Fixes #18

### DIFF
--- a/manifests/opendatahub/overlays/ml-pipeline-ui/deployments/ml-pipeline-ui.yaml
+++ b/manifests/opendatahub/overlays/ml-pipeline-ui/deployments/ml-pipeline-ui.yaml
@@ -28,8 +28,7 @@ spec:
             - --tls-cert=/etc/tls/private/tls.crt
             - --tls-key=/etc/tls/private/tls.key
             - --cookie-secret=SECRET
-            - '--openshift-delegate-urls={"/": {"resource": "route", "verb": "get", "name": "ml-pipeline-ui"}}'
-            - '--openshift-sar={"resource": "route", "resourceName": "ml-pipeline-ui", "verb": "get"}'
+            - '--openshift-delegate-urls={"/": {"resource": "services", "verb": "get", "name": "ml-pipeline-ui"}}'
             - --skip-auth-regex='(^/metrics|^/apis/v1beta1/healthz)'
           image: registry.redhat.io/openshift4/ose-oauth-proxy:v4.8
           ports:


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:** 
Resolves #18 

**Description of your changes:**
I discovered an issue where users require cluster admin in order to be
able to access the ML Pipelines UI. Only view (or similar) level
permissions should be required on the namespace. This change modifies
the parameters for the ml pipelines oauth proxy to match what we're
using now in other pods in the ODH.

**Environment tested:**

* Python Version (use `python --version`):
* Tekton Version (use `tkn version`):
* Kubernetes Version (use `kubectl version`): OpenShift 4.11
* OS (e.g. from `/etc/os-release`):

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
