### PR TITLE
Updating image name in Makefile

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,4 +1,4 @@
-IMAGE=odh-manifests-test
+IMAGE=ml-pipelines-tests
 GIT_ORG=opendatahub-io
 GIT_BRANCH=master
 ODHPROJECT=opendatahub


### PR DESCRIPTION
CI tests are failing because `ml-pipelines-tests` image is missing. Updating Makefile to have image name changed to `ml-pipelines-tests`.