### PR TITLE
Fix: Fixing applying patch / CI failure

### DIFF
--- a/tests/scripts/install.sh
+++ b/tests/scripts/install.sh
@@ -28,14 +28,14 @@ else
 fi
 popd
 ## Grabbing and applying the patch in the PR we are testing
-pushd ~/src/odh-manifests
+pushd ~/src/data-science-pipelines
 if [ -z "$PULL_NUMBER" ]; then
   echo "No pull number, assuming nightly run"
 else
   curl -O -L https://github.com/${REPO_OWNER}/${REPO_NAME}/pull/${PULL_NUMBER}.patch
-  echo "Applying followng patch:"
+  echo "Applying following patch:"
   cat ${PULL_NUMBER}.patch > ${ARTIFACT_DIR}/github-pr-${PULL_NUMBER}.patch
-  git apply ${PULL_NUMBER}.patch
+  git am ${PULL_NUMBER}.patch
 fi
 popd
 ## Point kfctl_openshift.yaml to the manifests in the PR
@@ -43,7 +43,7 @@ pushd ~/kfdef
 if [ -z "$PULL_NUMBER" ]; then
   echo "No pull number, not modifying kfctl_openshift.yaml"
 else
-  if [ $REPO_NAME == "odh-manifests" ]; then
+  if [ $REPO_NAME == "data-science-pipelines" ]; then
     echo "Setting manifests in kfctl_openshift to use pull number: $PULL_NUMBER"
     sed -i "s#uri: https://github.com/opendatahub-io/odh-manifests/tarball/master#uri: https://api.github.com/repos/opendatahub-io/odh-manifests/tarball/pull/${PULL_NUMBER}/head#" ./kfctl_openshift.yaml
   fi


### PR DESCRIPTION
[OpenShift CI renaming PR]( https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/openshift_release/33037/rehearse-33037-pull-ci-opendatahub-io-data-science-pipelines-master-data-science-pipelines-e2e/1580273674802434048/artifacts/data-science-pipelines-e2e/e2e/build-log.txt) is failing because of patching issues.

Replacing `git apply` with `git am` to resolve this issue, as per [this article](https://stackoverflow.com/questions/26111224/how-to-properly-apply-a-patch-with-moved-renamed-files-using-git)

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 