### PR TITLE
chore: Removing samples' directory from the APIServer image

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -29,36 +29,10 @@ RUN go-licenses csv ./backend/src/apiserver > /tmp/licenses.csv && \
     diff /tmp/licenses.csv backend/third_party_licenses/apiserver.csv && \
     go-licenses save ./backend/src/apiserver --save_path /tmp/NOTICES
 
-# 2. Compile preloaded pipeline samples
-FROM python:3.7 as compiler
-RUN apt-get update -y && apt-get install --no-install-recommends -y -q default-jdk python3-setuptools python3-dev jq
-RUN wget https://bootstrap.pypa.io/get-pip.py && python3 get-pip.py
-COPY sdk/python/requirements.txt .
-RUN python3 -m pip install -r requirements.txt --no-cache-dir
+# Remove sample_config.json file
+RUN rm /config/sample_config.json
 
-WORKDIR /go/src/github.com/kubeflow/pipelines
-COPY sdk sdk
-WORKDIR /go/src/github.com/kubeflow/pipelines/sdk/python
-RUN python3 setup.py install
-
-WORKDIR /
-COPY ./samples /samples
-COPY backend/src/apiserver/config/sample_config.json /samples/
-
-# Compiling the preloaded samples.
-# The default image is replaced with the GCR-hosted python image.
-RUN set -e; \
-    < /samples/sample_config.json jq .[].file --raw-output | while read pipeline_yaml; do \
-        pipeline_py="${pipeline_yaml%.yaml}.py"; \
-        pipeline_py="${pipeline_yaml%.yaml}.py"; \
-        mode=`< /samples/sample_config.json jq ".[] | select(.file == \"${pipeline_yaml}\") | (if .mode == null then \"V1\" else .mode end)" --raw-output`; \
-        mv "$pipeline_py" "${pipeline_py}.tmp"; \
-        echo 'import kfp; kfp.components.default_base_image_or_builder="gcr.io/google-appengine/python:2020-03-31-141326"' | cat - "${pipeline_py}.tmp" > "$pipeline_py"; \
-        dsl-compile-tekton --py "$pipeline_py" --output "$pipeline_yaml" || python3 "$pipeline_py"; \
-    done
-
-
-# 3. Start api web server
+# 2. Start api web server
 FROM debian:stable
 
 ARG COMMIT_SHA=unknown
@@ -74,7 +48,6 @@ COPY --from=builder /bin/apiserver /bin/apiserver
 # Copy licenses and notices.
 COPY --from=builder /tmp/licenses.csv /third_party/licenses.csv
 COPY --from=builder /tmp/NOTICES /third_party/NOTICES
-COPY --from=compiler /samples/ /samples/
 RUN chmod +x /bin/apiserver
 
 # Adding CA certificate so API server can download pipeline through URL and wget is used for liveness/readiness probe command

--- a/backend/src/apiserver/config/sample_config.json
+++ b/backend/src/apiserver/config/sample_config.json
@@ -1,7 +1,0 @@
-[
-  {
-    "name": "[Demo] flip-coin",
-    "description": "[source code](https://github.com/opendatahub-io/data-science-pipelines/tree/master/samples/flip-coin) A conditional pipeline to flip coins based on a random number generator.",
-    "file": "/samples/flip-coin/condition.yaml"
-  }
-]


### PR DESCRIPTION
**Description of your changes:**
Removing samples' directory containing the flip-coin example PipelineRun yaml, and the `sample_config.json` calling the yaml from the APIServer image.

[This rhods-live-builder commit](https://gitlab.cee.redhat.com/data-hub/rhods-live-builder/-/commit/5a1398298f3dc4498d42bf7eddf45fa091deeec5#1e3cc377585ba8dcbb60a31d67ebdbb589132341_84_39) is used as a reference for these changes.

A ConfigMap would be eventually added separately to load the sample flip-coin example on the DS Pipelines UI.


**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
