### PR TITLE
fix(backend): Update artifact-manager image to use Python 3.9

### DIFF
--- a/backend/artifact_manager/Dockerfile
+++ b/backend/artifact_manager/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/python-38
+FROM registry.access.redhat.com/ubi8/python-39
 WORKDIR /opt/app-root/src
 COPY backend/artifact_manager/requirements.txt /opt/app-root/src
 COPY backend/artifact_manager/setup.cfg /opt/app-root/src


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:** 
Resolves #[RHODS-7915](https://issues.redhat.com//browse/RHODS-7915)

**Description of your changes:**
Updates artifact-manager to use ubi8/python-3.9 as base image.
