### PR TITLE
Limit rev parse for tag-rel action.

### DIFF
--- a/.github/workflows/tag-release-quay.yml
+++ b/.github/workflows/tag-release-quay.yml
@@ -47,7 +47,7 @@ jobs:
         run: echo "tag=$(git describe --tags --abbrev=0)" >> ${GITHUB_OUTPUT}
       - name: Get latest tag hash
         id: hash
-        run: echo "hash=$(git rev-parse --short ${{ steps.tag.outputs.tag }} )" >> ${GITHUB_OUTPUT}
+        run: echo "hash=$(git rev-parse --short=7 ${{ steps.tag.outputs.tag }} )" >> ${GITHUB_OUTPUT}
       - name: Create new tag
         shell: bash
         env:


### PR DESCRIPTION
Resolves this error in github actions: 

> time="2023-06-16T17:20:37Z" level=fatal msg="initializing source docker://quay.io/opendatahub/ds-pipelines-api-server:main-0ad8ced47: reading manifest main-0ad8ced47 in quay.io/opendatahub/ds-pipelines-api-server: manifest unknown: manifest unknown" 

