### PR TITLE
Revise latest tag fetch script for release.

### DIFF
--- a/.github/workflows/tag-release-quay.yml
+++ b/.github/workflows/tag-release-quay.yml
@@ -44,7 +44,7 @@ jobs:
          skopeo login quay.io -u ${QUAY_ROBOT_USERNAME} -p ${QUAY_ROBOT_TOKEN}
       - name: Get latest tag name
         id: tag
-        run: echo "tag=$(git describe --tags --abbrev=0)" >> ${GITHUB_OUTPUT}
+        run: echo "tag=$(git tag | tail -n 1)" >> ${GITHUB_OUTPUT}
       - name: Get latest tag hash
         id: hash
         run: echo "hash=$(git rev-parse --short=7 ${{ steps.tag.outputs.tag }} )" >> ${GITHUB_OUTPUT}


### PR DESCRIPTION
We want to fetch the latest tag even if it has no new commit, this is because while DSP repo may not have new changes, DSPO repo may, and the two serve as a holistic offering and thus have sync'd versions. We can simply list out the tags and pick the newest ones, `git tag` will display the tags in sorted order, so this fix should suffice.