### PR TITLE
chore: Opt out as reviewers for data-science-pipeline

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -4,7 +4,6 @@ approvers:
   - DharmitD
   - gmfrasca
   - gregsheremeta
-  - harshad16
   - HumairAK
   - rimolive
 reviewers:
@@ -12,6 +11,7 @@ reviewers:
   - DharmitD
   - gmfrasca
   - gregsheremeta
-  - harshad16
   - HumairAK
   - rimolive
+emeritus_approvers:
+  - harshad16


### PR DESCRIPTION
Opt out as reviewers for data-science-pipeline-operator

**Which issue is resolved by this Pull Request:** 
Resolves #

Not sure, if this needed. 

**Description of your changes:**

As my focus has shifted a bit, I haven't been able to provide total support in reviewing the PRs.
I want to opt-out as a reviewer for now and continue acting as a contributor going forward.

Thank you to the team.
